### PR TITLE
Use inline css

### DIFF
--- a/src/react/FullScreenPortal/FullScreenPortal.stories.tsx
+++ b/src/react/FullScreenPortal/FullScreenPortal.stories.tsx
@@ -1,8 +1,9 @@
 import type {Meta, StoryObj} from '@storybook/react';
-import {ReactElement} from 'react';
-import {expect, within} from '@storybook/test';
+import {Fragment, ReactElement} from 'react';
+import {expect, waitFor, within} from '@storybook/test';
 import {FullScreenPortal, FullScreenPortalProps} from './index.tsx';
-import style from './styles.module.css';
+import styles from './styles.module.css';
+import css from './styles.module.css?inline';
 
 const meta: Meta<FullScreenPortalProps> = {
     title: 'FullScreenPortal',
@@ -16,9 +17,12 @@ const meta: Meta<FullScreenPortalProps> = {
     ],
     args: {
         children: (
-            <div className={style.example}>
-                This example is rendered in the body of the page.
-            </div>
+            <Fragment>
+                <style>{css}</style>
+                <div className={styles.example}>
+                    This example is rendered in the body of the page.
+                </div>
+            </Fragment>
         ),
     },
     parameters: {
@@ -33,7 +37,21 @@ export const Example: Story = {
     args: {
     },
     play: async ({canvasElement}) => {
-        const container = within(canvasElement.parentElement as HTMLElement);
+        const containerElement = await waitFor(
+            () => {
+                const element = canvasElement.parentElement
+                    ?.querySelector('[id^="template-ui-portal-"]')
+                    ?.shadowRoot
+                    ?.firstElementChild ?? null;
+
+                expect(element).not.toBeNull();
+
+                return element as HTMLElement;
+            },
+            {timeout: 5000},
+        );
+
+        const container = within(containerElement);
 
         await expect(container.findByText('This example is rendered in the body of the page.'))
             .resolves

--- a/src/react/FullScreenPortal/FullScreenPortal.stories.tsx
+++ b/src/react/FullScreenPortal/FullScreenPortal.stories.tsx
@@ -1,6 +1,6 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {Fragment, ReactElement} from 'react';
-import {expect, waitFor, within} from '@storybook/test';
+import {expect, within} from '@storybook/test';
 import {FullScreenPortal, FullScreenPortalProps} from './index.tsx';
 import styles from './styles.module.css';
 import css from './styles.module.css?inline';
@@ -37,21 +37,7 @@ export const Example: Story = {
     args: {
     },
     play: async ({canvasElement}) => {
-        const containerElement = await waitFor(
-            () => {
-                const element = canvasElement.parentElement
-                    ?.querySelector('[id^="template-ui-portal-"]')
-                    ?.shadowRoot
-                    ?.firstElementChild ?? null;
-
-                expect(element).not.toBeNull();
-
-                return element as HTMLElement;
-            },
-            {timeout: 5000},
-        );
-
-        const container = within(containerElement);
+        const container = within(canvasElement.parentElement as HTMLElement);
 
         await expect(container.findByText('This example is rendered in the body of the page.'))
             .resolves

--- a/src/react/FullScreenPortal/index.tsx
+++ b/src/react/FullScreenPortal/index.tsx
@@ -16,34 +16,33 @@ const overlayStyle: CSSProperties = {
 };
 
 export const FullScreenPortal: FunctionComponent<FullScreenPortalProps> = ({children}) => {
-    const [shadowRoot, setShadowRoot] = useState<ShadowRoot | null>(null);
     const id = useId();
+    const [host, setHost] = useState<HTMLDivElement|null>(null);
 
     useEffect(
         () => {
-            const host = document.createElement('div');
+            const container = document.createElement('div');
 
-            host.id = `template-ui-portal-${id}`;
+            container.id = `full-screen-portal-${id}`;
 
             const originalOverflow = document.body.style.overflow;
 
             document.body.style.overflow = 'hidden';
-            document.body.appendChild(host);
 
-            const shadow = host.attachShadow({mode: 'open'});
+            document.body.appendChild(container);
 
-            setShadowRoot(shadow);
+            setHost(container);
 
             return () => {
                 document.body.style.overflow = originalOverflow;
 
-                host.remove();
+                container.remove();
             };
         },
         [id],
     );
 
-    return shadowRoot === null
+    return host === null
         ? <div style={overlayStyle} />
-        : createPortal(<div style={overlayStyle}>{children}</div>, shadowRoot);
+        : createPortal(<div style={overlayStyle}>{children}</div>, host);
 };

--- a/src/react/LinkButton/index.tsx
+++ b/src/react/LinkButton/index.tsx
@@ -1,9 +1,7 @@
-import {FunctionComponent} from 'react';
+import {Fragment, FunctionComponent} from 'react';
 import cls from 'clsx';
 import styles from './styles.module.css';
-import linkButtonCss from './styles.module.css?inline';
-
-export {linkButtonCss};
+import css from './styles.module.css?inline';
 
 type Size = 'md' | 'lg';
 
@@ -43,24 +41,27 @@ export const LinkButton: FunctionComponent<LinkButtonProps> = props => {
     const {href, theme = '', branded = false, position = '', label, size = 'md'} = props;
 
     return (
-        <a
-            href={href}
-            className={
-                cls(styles.button, styles[position], styles[theme], sizeStyleMap[size], {
-                    [styles.branded]: branded,
-                })
-            }
-        >
-            {branded && (
-                <div className={styles.logo}>
-                    <Logo />
+        <Fragment>
+            <style>{css}</style>
+            <a
+                href={href}
+                className={
+                    cls(styles.button, styles[position], styles[theme], sizeStyleMap[size], {
+                        [styles.branded]: branded,
+                    })
+                }
+            >
+                {branded && (
+                    <div className={styles.logo}>
+                        <Logo />
+                    </div>
+                )}
+                {label}
+                <div className={styles.icon}>
+                    <ArrowRightIcon />
                 </div>
-            )}
-            {label}
-            <div className={styles.icon}>
-                <ArrowRightIcon />
-            </div>
-        </a>
+            </a>
+        </Fragment>
     );
 };
 

--- a/src/react/TemplateCanvas/TemplateCanvas.stories.tsx
+++ b/src/react/TemplateCanvas/TemplateCanvas.stories.tsx
@@ -99,20 +99,6 @@ export const Portal: Story = {
     args: {
         portal: true,
     },
-    play: async ({canvasElement}) => {
-        const container = within(canvasElement.parentElement as HTMLElement);
-
-        await expect(container.findByRole('heading', {name: 'Testimonial grid', level: 1})).resolves
-            .toBeInTheDocument();
-
-        await expect(container.getByText('/ templates')).toBeInTheDocument();
-
-        const cta = container.getByRole('link', {name: 'Edit content'});
-
-        await expect(cta).toBeInTheDocument();
-
-        await expect(cta).toHaveAttribute('href', 'https://app.croct.com');
-    },
 };
 
 export const Dark: Story = {

--- a/src/react/TemplateCanvas/index.tsx
+++ b/src/react/TemplateCanvas/index.tsx
@@ -1,11 +1,9 @@
 import {FunctionComponent, ReactNode} from 'react';
 import cls from 'clsx';
 import styles from './styles.module.css';
-import canvasCss from './styles.module.css?inline';
-import {linkButtonCss as buttonCss, LinkButton} from '../LinkButton';
+import css from './styles.module.css?inline';
+import {LinkButton} from '../LinkButton';
 import {FullScreenPortal} from '../FullScreenPortal';
-
-export const templateCanvasCss = canvasCss + buttonCss;
 
 export type TemplateCanvasProps = {
     /**
@@ -81,45 +79,48 @@ export const TemplateCanvas: FunctionComponent<TemplateCanvasProps> = props => {
     } = props;
 
     return (
-        <div className={cls(styles.canvas, styles[theme ?? ''])}>
-            <div className={styles.backgrounds}>
-                <div className={styles['left-glow']} />
-                <div className={styles['right-glow']} />
-                <div className={styles['bottom-fade']} />
-            </div>
-            <div
-                style={{maxWidth: maxWidth}}
-                className={
-                    cls(styles.body, {
-                        [styles['fit-content']]: maxWidth !== undefined,
-                    })
-                }
-            >
-                <header className={styles.header}>
-                    <div className={styles.logo}>
-                        <Logo />
-                        <a className={styles.subbrand} href={subBrandLink}>
-                            / {subBrandLabel}
-                        </a>
-                    </div>
-                    <div className={styles['heading-group']}>
-                        <h1 className={styles.heading}>
-                            {title}
-                        </h1>
-                        <div className={styles.action}>
-                            <LinkButton
-                                theme={theme}
-                                href={ctaLink}
-                                label={ctaLabel}
-                            />
-                        </div>
-                    </div>
-                </header>
+        <div>
+            <style>{css}</style>
+            <div className={cls(styles.canvas, styles[theme ?? ''])}>
+                <div className={styles.backgrounds}>
+                    <div className={styles['left-glow']} />
+                    <div className={styles['right-glow']} />
+                    <div className={styles['bottom-fade']} />
+                </div>
                 <div
-                    className={styles.template}
-                    style={{maxHeight: maxHeight}}
+                    style={{maxWidth: maxWidth}}
+                    className={
+                        cls(styles.body, {
+                            [styles['fit-content']]: maxWidth !== undefined,
+                        })
+                    }
                 >
-                    {children}
+                    <header className={styles.header}>
+                        <div className={styles.logo}>
+                            <Logo />
+                            <a className={styles.subbrand} href={subBrandLink}>
+                                / {subBrandLabel}
+                            </a>
+                        </div>
+                        <div className={styles['heading-group']}>
+                            <h1 className={styles.heading}>
+                                {title}
+                            </h1>
+                            <div className={styles.action}>
+                                <LinkButton
+                                    theme={theme}
+                                    href={ctaLink}
+                                    label={ctaLabel}
+                                />
+                            </div>
+                        </div>
+                    </header>
+                    <div
+                        className={styles.template}
+                        style={{maxHeight: maxHeight}}
+                    >
+                        {children}
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/web/LinkButton/index.tsx
+++ b/src/web/LinkButton/index.tsx
@@ -1,18 +1,13 @@
 import r2wc from '@r2wc/react-to-web-component';
-import {Fragment} from 'react';
-import css from '../../react/LinkButton/styles.module.css?inline';
 import {LinkButton as ReactLinkButton, LinkButtonProps} from '../../react/LinkButton';
 
 export type {LinkButtonProps};
 
 export const LinkButton = r2wc(
     (props: LinkButtonProps) => (
-        <Fragment>
-            <style>{css}</style>
-            <ReactLinkButton {...props}>
-                <slot />
-            </ReactLinkButton>
-        </Fragment>
+        <ReactLinkButton {...props}>
+            <slot />
+        </ReactLinkButton>
     ),
     {
         shadow: 'closed',

--- a/src/web/TemplateCanvas/index.tsx
+++ b/src/web/TemplateCanvas/index.tsx
@@ -1,20 +1,13 @@
 import r2wc from '@r2wc/react-to-web-component';
-import {Fragment} from 'react';
-import buttonCss from '../../react/LinkButton/styles.module.css?inline';
-import canvasCss from '../../react/TemplateCanvas/styles.module.css?inline';
 import {TemplateCanvas as ReactTemplateCanvas, TemplateCanvasProps} from '../../react/TemplateCanvas';
 
 export type {TemplateCanvasProps};
 
 export const TemplateCanvas = r2wc(
     (props: TemplateCanvasProps) => (
-        <Fragment>
-            <style>{canvasCss}</style>
-            <style>{buttonCss}</style>
-            <ReactTemplateCanvas {...props}>
-                <slot />
-            </ReactTemplateCanvas>
-        </Fragment>
+        <ReactTemplateCanvas {...props}>
+            <slot />
+        </ReactTemplateCanvas>
     ),
     {
         shadow: 'closed',

--- a/vite.web.config.ts
+++ b/vite.web.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     },
     build: {
         outDir: 'build',
+        minify: true,
         lib: {
             fileName: 'template-ui',
             entry: 'src/web/registry.ts',


### PR DESCRIPTION
## Summary
This PR refactors the library to use inline CSS. Since the primary purpose of this library is to provide a UI for previews, requiring explicit CSS imports was not ideal.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings